### PR TITLE
feature-00002: Set Up CI Pipeline for RuboCop Linting and RSpec Testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: "CI"
+
+on:
+  push:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:11-alpine
+        ports:
+          - "5432:5432"
+        env:
+          POSTGRES_DB: rails_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+    env:
+      RAILS_ENV: test
+      DATABASE_URL: "postgres://postgres:postgres@localhost:5432/rails_test"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.2.2
+          bundler-cache: true
+
+      - name: Install Dependencies
+        run: cd backend && bundle install --jobs 4 --retry 3
+
+      - name: Set up database schema
+        run: cd backend && bin/rails db:schema:load
+
+      - name: Run tests
+        run: cd backend && bundle exec rspec spec
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.2.2
+          bundler-cache: true
+
+      - name: Install Dependencies
+        run: cd backend && bundle install --jobs 4 --retry 3
+
+      - name: Lint Ruby files
+        run: cd backend && bundle exec rubocop

--- a/backend/config/application.rb
+++ b/backend/config/application.rb
@@ -34,7 +34,7 @@ module Backend
     config.api_only = true
 
     config.middleware.insert_after Rack::Runtime, Rack::MethodOverride
-    config.middleware.insert_after ActiveRecord::Migration::CheckPending, ActionDispatch::Cookies
+    config.middleware.insert_after ActionDispatch::Callbacks, ActionDispatch::Cookies
     config.middleware.insert_after ActionDispatch::Cookies, ActionDispatch::Session::CookieStore
     config.middleware.insert_after ActionDispatch::Session::CookieStore, ActionDispatch::Flash
     config.middleware.use ActionDispatch::ContentSecurityPolicy::Middleware


### PR DESCRIPTION
Body: Create a Continuous Integration (CI) pipeline that automates the process of running RuboCop for code linting and RSpec for tests. The pipeline will be configured to automatically run these checks on each push event, ensuring code quality and preventing regressions.

Footer: See issue #00002 for more details